### PR TITLE
Change site URL in config

### DIFF
--- a/Sources/Blog/Blog.swift
+++ b/Sources/Blog/Blog.swift
@@ -19,7 +19,7 @@ struct Blog: Website {
         var excerpt: String
     }
 
-    var url = URL(string: "www.staskus.io")!
+    var url = URL(string: "https://www.staskus.io")!
     var title = "staskus.io"
     var name = "Povilas Staškus"
     var description = "iOS Developer"


### PR DESCRIPTION
I will readily admit that I haven't actually tested this, but in comparing to the [the Publish docs](https://github.com/johnsundell/publish#websites-as-swift-packages) I saw that the URL includes the scheme. Inspired by the fact that the canonical links in the RSS feed point to, for example, `https://www.staskus.io/www.staskus.io/posts/2020-06-23-app-clip` instead of `https://www.staskus.io/posts/2020-06-23-app-clip`